### PR TITLE
toString and toMap fail with null values

### DIFF
--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -192,6 +192,8 @@ class DijonSpec extends Specification {
       t.b.c.a must throwA[NullPointerException]
       t.b.c = v
       t.b.c.a must beNull
+
+      t.toString must not beNull
     }
 
     "handle merges" in {


### PR DESCRIPTION
This was covered in #8 but was closed due to passing tests.  Attempting this in the repl fails due to the `toString` call:

```
scala> import com.github.pathikrit.dijon._
import com.github.pathikrit.dijon._

scala> parse(""" { "test": null } """)
java.lang.NullPointerException
  at scala.util.parsing.json.JSONFormat$$anonfun$1.apply(Parser.scala:61)
  at scala.util.parsing.json.JSONFormat$$anonfun$1.apply(Parser.scala:57)
  at scala.util.parsing.json.JSONObject$$anonfun$toString$1.apply(Parser.scala:99)
  at scala.util.parsing.json.JSONObject$$anonfun$toString$1.apply(Parser.scala:99)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
  at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
  at scala.collection.immutable.Map$Map1.foreach(Map.scala:116)
  at scala.collection.TraversableLike$class.map(TraversableLike.scala:245)
  at scala.collection.AbstractTraversable.map(Traversable.scala:104)
  at scala.util.parsing.json.JSONObject.toString(Parser.scala:99)
  at scala.util.parsing.json.JSONType.toString(Parser.scala:34)
  at com.github.pathikrit.dijon.package$Json.toString(package.scala:72)
  at scala.runtime.ScalaRunTime$.scala$runtime$ScalaRunTime$$inner$1(ScalaRunTime.scala:332)
```

I've added an expectation that fails with the `NullPointerException`.  
