### PR TITLE
Changing null to None

### DIFF
--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -59,6 +59,11 @@ package object dijon {
       case _ => this
     }
 
+    def remove(keys: String*): Unit = underlying match {
+      case obj: JsonObject => obj --= keys
+      case _ => this
+    }
+
     def as[T : JsonType : TypeTag]: Option[T] = underlying match {
       case x: T => Some(x)
       case _ => None

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -178,6 +178,8 @@ class DijonSpec extends Specification {
       var basicCat = cat -- "vet"                                  // remove 1 key
       basicCat = basicCat -- ("hobbies", "is cat", "paws")         // remove multiple keys ("paws" is not in cat)
       assert(basicCat == json"""{ "name": "Tigri", "age": 7}""")   // after dropping some keys above
+      basicCat.remove("age")                                       // remove 1 key by mutating object
+      assert(basicCat == json"""{ "name": "Tigri" }""")
 
       (cat.vet.address -- "city") mustEqual json"""{ "name" : "Animal Hospital", "zip": 94306}"""
     }


### PR DESCRIPTION
This resolves inconsistencies between the usage of null and None, in favor of None. Now the json "null" is always represented internally by the scala "None".

Addresses issue #19 and pr #16.
