### PR TITLE
Allow for JSON parser creating Ints

### DIFF
--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -91,6 +91,7 @@ package object dijon {
     case x: Seq[Any] => mutable.Buffer[SomeJson](x map assemble : _*)
     case x: String => x
     case x: Double => x
+    case x: Int => x
     case x: Boolean => x
   }
 

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -2,6 +2,7 @@ package com.github.pathikrit.dijon
 
 import org.specs2.mutable.Specification
 import scala.collection.mutable
+import scala.util.parsing.json.JSON
 
 class DijonSpec extends Specification {
 
@@ -371,6 +372,18 @@ class DijonSpec extends Specification {
       parse(obj.toString) mustEqual obj
       json""" { "greet": "hi\\"",
                 "nested": { "inner": "ho\\"" } } """ mustEqual obj
+    }
+
+    "handle numbers represented as integers" in {
+      val defaultNumberParser = JSON.perThreadNumberParser
+      JSON.perThreadNumberParser = _.toInt //change underlying JSON parser to create Ints instead of Doubles
+
+      val jsonStr = """{"anInt" : 1}"""
+      val obj = parse(jsonStr)
+
+      JSON.perThreadNumberParser = defaultNumberParser //reset number parser to original
+
+      obj.anInt mustEqual 1
     }
   }
 }


### PR DESCRIPTION
The underlying JSON parser `scala.util.parsing.json.JSON` allows the user to change the number parser. The default always parses numbers into doubles, but a user may be interested in parsing some numbers into integers. 

This exposes a bug in dijon's `assemble` method, which this commit fixes.
