### PR TITLE
Changing null to None

### DIFF
--- a/src/main/scala/com/github/pathikrit/dijon/package.scala
+++ b/src/main/scala/com/github/pathikrit/dijon/package.scala
@@ -38,7 +38,7 @@ package object dijon {
 
     def update(index: Int, value: SomeJson): Unit = underlying match {
       case arr: JsonArray if index >= 0 =>
-        while(arr.size <= index) { arr += null }
+        while(arr.size <= index) { arr += None }
         arr(index) = value
       case _ =>
     }
@@ -72,6 +72,7 @@ package object dijon {
       case obj: JsonObject => new JSONObject(obj.toMap).toString
       case arr: JsonArray => arr mkString ("[", ", ", "]")
       case str: String => s""""${str.replace("\"", "\\\"").replace("\n", raw"\n")}""""
+      case _: None.type => "null"
       case _ => underlying.toString
     }
 
@@ -86,7 +87,7 @@ package object dijon {
   def parse(s: String): SomeJson = (JSON.parseFull(s) map assemble) getOrElse (throw new IllegalArgumentException("Invalid JSON"))
 
   def assemble(s: Any): SomeJson = s match {
-    case null => null
+    case null => None
     case x: Map[String, Any] => mutable.Map((x mapValues assemble).toSeq : _*)
     case x: Seq[Any] => mutable.Buffer[SomeJson](x map assemble : _*)
     case x: String => x

--- a/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
+++ b/src/test/scala/com/github/pathikrit/dijon/DijonSpec.scala
@@ -86,8 +86,8 @@ class DijonSpec extends Specification {
       rick.hobbies(2)(100) mustEqual None
       rick.hobbies(2)(100) mustNotEqual null
 
-      rick.hobbies(3) mustEqual null
-      rick.hobbies(3) mustNotEqual None
+      rick.hobbies(3) mustEqual None
+      rick.hobbies(3) mustNotEqual null
       rick.hobbies(4) mustNotEqual null
       rick.hobbies(4) mustEqual None
 
@@ -115,7 +115,7 @@ class DijonSpec extends Specification {
       b must beTrue
 
       val n = arr(2)
-      assert(n == null)
+      assert(n == None)
 
       val Some(s: String) = arr(3).as[String]
       s mustEqual "hi"
@@ -159,7 +159,7 @@ class DijonSpec extends Specification {
       vet.phones = `[]`                   // create empty json array
       val phone = "(650) 493-4233"
       vet.phones(2) = phone               // set the 3rd item in array to this phone
-      assert(vet.phones == mutable.Seq(null, null, phone))  // first 2 entries null
+      assert(vet.phones == mutable.Seq(None, None, phone))  // first 2 entries None
 
       vet.address = `{}`
       vet.address.name = "Animal Hospital"
@@ -183,15 +183,16 @@ class DijonSpec extends Specification {
 
     "handle nulls" in {
       val t = json"""{"a": null, "b": {"c": null}}"""
-      t.a must beNull
-      t.b.c must beNull
+      t.a mustEqual None
+      t.b.c mustEqual None
 
       val v = parse("""{"a": null}""")
-      v.a must beNull
+      v.a mustEqual None
 
-      t.b.c.a must throwA[NullPointerException]
+      assert(t == parse(t.toString)) //round-trip test
+
       t.b.c = v
-      t.b.c.a must beNull
+      t.b.c.a mustEqual None
     }
 
     "handle merges" in {
@@ -244,7 +245,7 @@ class DijonSpec extends Specification {
       val langs = json"""["scala", ["python2", "python3"]]"""
       langs(-2) = "java"
       langs(5) = "F#"
-      langs(3) mustEqual null
+      langs(3) mustEqual None
       langs(5) mustEqual "F#"
       langs(1)(3) = "python4"
       langs(1)(3) mustEqual "python4"


### PR DESCRIPTION
This resolves inconsistencies between the usage of null and None, in favor of None. Now the json "null" is always represented internally by the scala "None".

Addresses issue #19 and pr #16.

(Originally opened as #23, but I needed to change the base branch from master).
